### PR TITLE
Allow Objective C projects to instantiate INSPhoto objects

### DIFF
--- a/INSPhotoGallery/INSPhoto.swift
+++ b/INSPhotoGallery/INSPhoto.swift
@@ -33,7 +33,7 @@ import UIKit
     var attributedTitle: NSAttributedString? { get }
 }
 
-open class INSPhoto: INSPhotoViewable, Equatable {
+@objc open class INSPhoto: NSObject, INSPhotoViewable {
     @objc open var image: UIImage?
     @objc open var thumbnailImage: UIImage?
     
@@ -52,7 +52,7 @@ open class INSPhoto: INSPhotoViewable, Equatable {
         self.thumbnailImageURL = thumbnailImageURL
     }
     
-    public init (imageURL: URL?, thumbnailImage: UIImage) {
+    public init (imageURL: URL?, thumbnailImage: UIImage?) {
         self.imageURL = imageURL
         self.thumbnailImage = thumbnailImage
     }


### PR DESCRIPTION
Example of use:
```

NSMutableArray *photos = [NSMutableArray array];

for ( NSString *urlPath in array) {
	INSPhoto *photo = [[INSPhoto alloc] initWithImageURL:[NSURL URLWithString:urlPath]
                                          thumbnailImage:nil];
    [photos addObject:photo];
}
if (photos.count > 0) 
	INSPhotosViewController *galleryPreview = [[INSPhotosViewController alloc] initWithPhotos:photos initialPhoto:photos[0] referenceView:view];
```

