### PR TITLE
fix to make it compile with Xcode 9 beta 4

### DIFF
--- a/INSPhotoGallery/INSPhotosOverlayView.swift
+++ b/INSPhotoGallery/INSPhotosOverlayView.swift
@@ -55,7 +55,7 @@ open class INSPhotosOverlayView: UIView , INSPhotosOverlayViewable {
             navigationItem.rightBarButtonItem = rightBarButtonItem
         }
     }
-    var titleTextAttributes: [String : AnyObject] = [:] {
+    var titleTextAttributes: [NSAttributedStringKey : AnyObject] = [:] {
         didSet {
             navigationBar.titleTextAttributes = titleTextAttributes
         }

--- a/INSPhotoGallery/INSPhotosViewController.swift
+++ b/INSPhotoGallery/INSPhotosViewController.swift
@@ -166,7 +166,7 @@ open class INSPhotosViewController: UIViewController, UIPageViewControllerDataSo
         let textColor = view.tintColor ?? UIColor.white
         if let overlayView = overlayView as? INSPhotosOverlayView {
             overlayView.photosViewController = self
-            overlayView.titleTextAttributes = [NSForegroundColorAttributeName: textColor]
+            overlayView.titleTextAttributes = [NSAttributedStringKey(rawValue: NSAttributedStringKey.foregroundColor.rawValue): textColor]
         }
     }
     


### PR DESCRIPTION
I'm not sure if this is new but the declaration for the navigationBar titleTextAttributes is:

```swift
@available(iOS 5.0, *)
open var titleTextAttributes: [NSAttributedStringKey : Any]?
```

so that caused a compilation error in the newest version of Xcode beta, this commit fixes it.

I'm not sure if this should be on the master branch or a feature branch for swift-4 but since it's the only public branch, here you go 😀.