### PR TITLE
Calling updateCurrentPhotosInformation in viewDidAppear

### DIFF
--- a/INSPhotoGallery/INSPhotosViewController.swift
+++ b/INSPhotoGallery/INSPhotosViewController.swift
@@ -198,10 +198,10 @@ open class INSPhotosViewController: UIViewController, UIPageViewControllerDataSo
         UIView.animate(withDuration: 0.25) { () -> Void in
             self.setNeedsStatusBarAppearanceUpdate()
         }
+        updateCurrentPhotosInformation()
     }
     
     private func setupOverlayView() {
-        updateCurrentPhotosInformation()
         
         overlayView.view().autoresizingMask = [.flexibleWidth, .flexibleHeight]
         overlayView.view().frame = view.bounds


### PR DESCRIPTION
Calling updateCurrentPhotosInformation in viewDidAppear because populateWithPhoto wasn't getting called on the first opening of PhotosViewController. It was called after swiping or clicking on the photo while PhotosViewController was displaying