### PR TITLE
 Swift Package Manager support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version:5.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "INSPhotoGallery",    
+    platforms: [
+      .iOS(.v8)
+    ],
+    products: [        
+        .library(name: "INSPhotoGallery", targets: ["INSPhotoGallery"]),
+    ],
+    targets: [     
+        .target(name: "INSPhotoGallery", path: "INSPhotoGallery"),
+    ]
+)


### PR DESCRIPTION
Fixes #68  by adding Swift Package Manager support.

To make it work "properly" it should be releases as a next release (1.2.9) otherwise it will not work "put of the box" but users will have to specific master as target branch instead fixing a version.